### PR TITLE
default setup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '2'
+services:
+  privatebin:
+    image: "privatebin/nginx-fpm-alpine"
+    ports:
+     - "8898:8080"
+
+  nginx:
+    image: "nginx"
+    ports:
+    - "8899:80"
+    volumes:
+    - ./nginx.conf:/etc/nginx/nginx.conf:ro

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,11 @@
+events { worker_connections 1024; }
+
+http {
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass http://privatebin:8080/;
+        }
+    }
+}


### PR DESCRIPTION
default set-up, the `docker compose up` created a network with:
- 172.19.0.1 : localhost
- 172.19.0.2 : nginx reverse proxy
- 172.19.0.3 : privatebin

the service is accessible by the localhost at both:
- http://localhost:8898/ : privatebin direct access (localhost:8898 => privatebin:8080)
- http://localhost:8899/ : proxied privatebin  : (localhost:8899 => nginx:80 => privatebin:8080)